### PR TITLE
Remove colormath dependency in favor of colorsys (builtin)

### DIFF
--- a/pyvantage/__init__.py
+++ b/pyvantage/__init__.py
@@ -124,9 +124,7 @@ import traceback
 from collections import deque
 from xml.sax.saxutils import escape
 
-from colormath.color_objects import sRGBColor, HSVColor
-from colormath.color_conversions import convert_color
-
+from colorsys import hsv_to_rgb, rgb_to_hsv
 
 def kelvin_to_level(kelvin):
     """Convert kelvin temperature to a USAI level."""
@@ -1850,9 +1848,8 @@ class Output(VantageEntity):
         _LOGGER.debug("%s: rgb = %s", self,
                       json.dumps(new_rgb))
         # INVOKE [vid] RGBLoad.SetRGBW [val0], [val1], [val2], [val3]
-        srgb = sRGBColor(*new_rgb)
-        hs_color = convert_color(srgb, HSVColor)
-        self._hs = [hs_color.hsv_h, hs_color.hsv_s * 100.0]
+        hs_color = rgb_to_hsv(*new_rgb)
+        self._hs = [hs_color[0] * 360.0, hs_color[1] * 100.0]
         self._rgb = new_rgb
         self._rgb_is_dirty = True
         if self._level > 0:
@@ -1884,9 +1881,7 @@ class Output(VantageEntity):
         _LOGGER.debug("%s: hs = %s", self,
                       json.dumps(new_hs))
         self._hs = new_hs
-        hs_color = HSVColor(new_hs[0], new_hs[1]/100.0, 1.0)
-        rgb = convert_color(hs_color, sRGBColor)
-        self._rgb = [rgb.rgb_r, rgb.rgb_g, rgb.rgb_b]
+        self._rgb = list(hsv_to_rgb(new_hs[0]/360.0, new_hs[1]/100.0, 1.0))
         self._invoke_hs()
 
     def _invoke_hs(self):


### PR DESCRIPTION
This removes the dependency on the `colormath` module, in favor of `colorsys`, which is a built-in. This also means we no longer have a transitive dependency on `numpy`.