### PR TITLE
Remove deprecated telnetlib

### DIFF
--- a/pyvantage/__init__.py
+++ b/pyvantage/__init__.py
@@ -249,8 +249,8 @@ class VantageConnection(threading.Thread):
         while True:
             try:
                 self._sockets[i] = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self._sockets[i].settimeout(2)
                 self._sockets[i].connect((self._host, self._cmd_port))
+                self._sockets[i].settimeout(2)
                 break
             except Exception as e:
                 _LOGGER.warning("Could not connect #%s to %s:%d, "


### PR DESCRIPTION
This pull request removes the dependency on the now deprecated `telnetlib` in favor of raw sockets.

This sets the groundwork for using secure connections for both file and command connections on port 2010 and 3010 respectively. I'll follow up with that work on a later PR.