### PR TITLE
Add support for secure sockets

### DIFF
--- a/pyvantage/__init__.py
+++ b/pyvantage/__init__.py
@@ -249,8 +249,8 @@ class VantageConnection(threading.Thread):
         while True:
             try:
                 self._sockets[i] = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self._sockets[i].settimeout(2)
                 self._sockets[i].connect((self._host, self._cmd_port))
+                self._sockets[i].settimeout(2)
                 break
             except Exception as e:
                 _LOGGER.warning("Could not connect #%s to %s:%d, "


### PR DESCRIPTION
Depends on #13.

This pull request adds support for communication via the SSL-enabled file (2010) and command (3010) ports.

SSL ports (2010/3010) are the only ports open by default on recent Vantage inFusion controller versions. Enabling the old non-SSL ports (2001/3001) requires access to the Design Center software or to speak with a Vantage dealer (ugh).

The PR adds a new optional parameter to the `Vantage` and `VantageConnection` classes called `use_ssl`, which currently defaults to `false` to maintain backwards compatibility.

Enabling `use_ssl` and setting `file_port` to 2010 and `cmd_port` to 3010 allows people to use this integration without access to Design Center or speaking to their dealer.

Example usage:

```python
vcl = pyvantage.Vantage("192.168.0.x", "vantage", "integration", file_port=2010, cmd_port=3010, use_ssl=True)
```

I have intentionally left the `use_ssl`, `file_port` and `cmd_ports` default values as the "non-SSL" values to maximize backwards compatibility and increase the chance of this being merged, but I would recommend that the defaults be changed to the SSL values in future